### PR TITLE
#30 java config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Java template
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+### Maven template
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+
+# Avoid ignoring Maven wrapper jar file (.jar files are usually ignored)
+!/.mvn/wrapper/maven-wrapper.jar
+
+
+.idea

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ public interface BankService {
 
 which will POST a JSON object similar to:
 
-```javascript
+```json
 {
 	"fromAccount":	{
 			"accountNumber": 1234,


### PR DESCRIPTION
This PR changes the code of a test to use JavaConfig,
this can be used as an example.

This PR also fix an issue with the `MultiThreaddedTest`, 
because the test never run for the cglib proxy, only for 
the `normal` proxy because it uses the `service` instance 
field instead of the `bankService` method parameter (method
`runMultiThreaddedTest`).